### PR TITLE
Refactoring Fenom\Template::compile: Removed goto, $from

### DIFF
--- a/tests/cases/Fenom/CommentTest.php
+++ b/tests/cases/Fenom/CommentTest.php
@@ -14,6 +14,10 @@ class CommentTest extends TestCase {
         $this->assertRender("before {*{{$tpl_val}}*} after", "before  after");
     }
 
+    public function testError() {
+        $this->execError('{* ', 'Fenom\CompileException', "Unclosed comment block in line");
+    }
+
 	/**
 	 * @dataProvider providerScalars
 	 */

--- a/tests/cases/Fenom/TemplateTest.php
+++ b/tests/cases/Fenom/TemplateTest.php
@@ -448,6 +448,7 @@ class TemplateTest extends TestCase {
             array('{if 0}none{/if} literal: {$a} end',                      $a, 'literal: lit. A end'),
             array('{if 0}none{/if} literal:{ignore} {$a} {/ignore} end',  $a, 'literal: {$a} end'),
             array('{if 0}none{/if} literal: { $a} end',                     $a, 'literal: { $a} end'),
+            array('{if 0}none{/if} literal: {  $a}{$a}{  $a} end',                     $a, 'literal: {  $a}lit. A{  $a} end'),
             array('{if 0}none{/if} literal: {
             $a} end',                                       $a, 'literal: { $a} end'),
             array('{if 0}none{/if}literal: function () { return 1; } end', $a, 'literal: function () { return 1; } end')


### PR DESCRIPTION
Refactoring Fenom\Template::compile: Removed goto, $from
Fixed issues with templates
    '{if 0}none{/if} literal: {  $a}{$a}{  $a} end'
    '{\* '
