### PR TITLE
fix bugs in getTemplate, improved performance

### DIFF
--- a/src/Fenom/Template.php
+++ b/src/Fenom/Template.php
@@ -407,11 +407,7 @@ class Template extends Render {
      * @param Render $tpl
      */
     public function addDepend(Render $tpl) {
-		$name = $tpl->getName();
-		if ($tpl->getScm()) {
-			$name = $tpl->getScm() . ':' . $name;
-		}
-		$this->_depends[$name] = $tpl->getTime();
+        $this->_depends[$tpl->getScm()][$tpl->getName()] = $tpl->getTime();
     }
 
     /**


### PR DESCRIPTION
There was a couple of bugs, slowing performance when AUTO_RELOAD is enabled.
I implemented additional test in benchmark.
Before bugfix:

```
Testing 1000 separate renderings...
 smarty3: stress test                4.5818 sec,        3.7 MiB
   fenom: stress test                6.2719 sec,       14.4 MiB
```

After bugfix:

```
Testing 1000 separate renderings...
 smarty3: stress test                4.6136 sec,        3.7 MiB
   fenom: stress test                3.5603 sec,       12.5 MiB
```
