### PR TITLE
Fix for unary operator ("!", "-", "~") before brackets in expression.

### DIFF
--- a/src/Fenom/Template.php
+++ b/src/Fenom/Template.php
@@ -608,7 +608,7 @@ class Template extends Render {
                 }
                 $term = 1;
             } elseif(!$term && $tokens->is(Tokenizer::MACRO_UNARY)) {
-                if(!$tokens->isNext(T_VARIABLE, T_DNUMBER, T_LNUMBER, T_STRING, T_ISSET, T_EMPTY)) {
+                if(!$tokens->isNext(T_VARIABLE, T_DNUMBER, T_LNUMBER, T_STRING, T_ISSET, T_EMPTY, '(')) {
                     break;
                 }
                 $_exp .= $tokens->getAndNext();

--- a/tests/cases/Fenom/TemplateTest.php
+++ b/tests/cases/Fenom/TemplateTest.php
@@ -166,8 +166,9 @@ class TemplateTest extends TestCase {
             array('Exp: {$y-$x} result',                        $b, 'Exp: 18 result'),
             array('Exp: {$y*$x} result',                        $b, 'Exp: 243 result'),
             array('Exp: {$y^$x} result',                        $b, 'Exp: 18 result'),
-            array('Exp: {-$x} result',                          $b, 'Exp: -9 result'),
+            array('Exp: {-($x)} result',                        $b, 'Exp: -9 result'),
             array('Exp: {!$x} result',                          $b, 'Exp: result'),
+            array('Exp: {!($x)} result',                        $b, 'Exp: result'),
             array('Exp: {!5} result',                           $b, 'Exp: result'),
             array('Exp: {-1} result',                           $b, 'Exp: -1 result'),
             array('Exp: {$z = 5} {$z} result',                  $b, 'Exp: 5 5 result'),
@@ -266,6 +267,8 @@ class TemplateTest extends TestCase {
             array('if: {if true} block1 {else} block2 {/if} end',             $a, 'if: block1 end'),
             array('if: {if false} block1 {else} block2 {/if} end',            $a, 'if: block2 end'),
             array('if: {if null} block1 {else} block2 {/if} end',             $a, 'if: block2 end'),
+            array('if: {if !($val0 || $val1)} block1 {else} block2 {/if} end',
+																			  $a, 'if: block2 end'),
         );
     }
 


### PR DESCRIPTION
Fix for expressions like `{if (!($a || $b))}`. They were failing to compile with error: `Fenom\UnexpectedTokenException: Unexpected token '!' in expression`.

Tests added.
