### PR TITLE
fix parseExp parsing arrays

### DIFF
--- a/src/Fenom/Template.php
+++ b/src/Fenom/Template.php
@@ -670,8 +670,9 @@ class Template extends Render {
                 }
                 $_exp[] = " ".$tokens->getAndNext()." ";
                 $term = 0;
-            } elseif($tokens->is('[')) {
+            } elseif(!$term && $tokens->is('[')) {
 				$_exp[] = $this->parseArray($tokens);
+				$term = 1;
             } else {
                 break;
             }


### PR DESCRIPTION
Fixes problem when `{myFunc 1 [2, 3, 4]}` becomes `<?= myFunc(1array(2, 3, 4)) ?>`.
Should use $term to terminate parsing or current expression before or after array.
