### PR TITLE
Update Fenom.php

### DIFF
--- a/src/Fenom.php
+++ b/src/Fenom.php
@@ -277,11 +277,11 @@ class Fenom
     }
 
     /**
-     * @param Fenom\ProviderInterface $provider
+     * @param $provider
      */
-    public function __construct(Fenom\ProviderInterface $provider)
+    public function __construct($provider)
     {
-        $this->_provider = $provider;
+        $this->_provider = new Fenom\Provider($provider);
     }
 
     /**


### PR DESCRIPTION
Не удобно каждый раз прописывать:
$fenom = new Fenom(new Provider('/path/to/templates'));
Гораздо удобнее так (что и было сделано):
$fenom = new Fenom('/path/to/templates');

Вдобавок, в маршрутах Symfony 2 нельзя передавать объекты в объект с параметром второго объекта. Можно объект + параметр. Для совместимости с Symfony 2 в конструкторе создание объекта перенесено из параметра в тело функции.
