### PR TITLE
Проверка на строку не нужна

### DIFF
--- a/src/Fenom/Modifier.php
+++ b/src/Fenom/Modifier.php
@@ -25,7 +25,7 @@ class Modifier
      */
     public static function dateFormat($date, $format = "%b %e, %Y")
     {
-        if (is_string($date) && !is_numeric($date)) {
+        if (!is_numeric($date)) {
             $date = strtotime($date);
             if (!$date) $date = time();
         }
@@ -39,7 +39,7 @@ class Modifier
      */
     public static function date($date, $format = "Y m d")
     {
-        if (is_string($date) && !is_numeric($date)) {
+        if (!is_numeric($date)) {
             $date = strtotime($date);
             if (!$date) $date = time();
         }
@@ -100,7 +100,7 @@ class Modifier
             if (preg_match('#^(.{' . $length . '}).*?(.{' . $length . '})?$#usS', $string, $match)) {
                 if (count($match) == 3) {
                     if ($by_words) {
-                        return preg_replace('#\s.*$#usS', "", $match[1]) . $etc . preg_replace('#^.*\s#usS', "", $match[2]);
+                        return preg_replace('#\s.*$#usS', "", $match[1]) . $etc . preg_replace('#.*\s#usS', "", $match[2]);
                     } else {
                         return $match[1] . $etc . $match[2];
                     }


### PR DESCRIPTION
- Проверка на строку не нужна
- В регулярном выражении нет необходимости указывать "^", так как .\* заякоривается автоматом.
