### PR TITLE
Замена Compiler::toArray на var_export

### DIFF
--- a/src/Fenom/Compiler.php
+++ b/src/Fenom/Compiler.php
@@ -40,9 +40,9 @@ class Compiler
                 $inc = $tpl->getStorage()->compile($name, false);
                 $tpl->addDepend($inc);
                 $var = $tpl->tmpVar();
-                return $var.' = (array)$tpl; $tpl->exchangeArray(' . self::toArray($p) . '+'.$var.'); ?>' . $inc->getBody() . '<?php $tpl->exchangeArray('.$var.'); unset('.$var.');';
+                return $var.' = (array)$tpl; $tpl->exchangeArray(' . var_export($p, true) . '+'.$var.'); ?>' . $inc->getBody() . '<?php $tpl->exchangeArray('.$var.'); unset('.$var.');';
             } else {
-                return '$tpl->getStorage()->getTemplate(' . $cname . ')->display(' . self::toArray($p) . '+(array)$tpl);';
+                return '$tpl->getStorage()->getTemplate(' . $cname . ')->display(' . var_export($p, true) . '+(array)$tpl);';
             }
         } else {
             if ($name && ($tpl->getStorage()->getOptions() & \Fenom::FORCE_INCLUDE)) {
@@ -687,7 +687,7 @@ class Compiler
      */
     public static function stdFuncParser($function, Tokenizer $tokens, Template $tpl)
     {
-        return "$function(" . self::toArray($tpl->parseParams($tokens)) . ', $tpl)';
+        return "$function(" . var_export($tpl->parseParams($tokens), true) . ', $tpl)';
     }
 
     /**
@@ -731,7 +731,7 @@ class Compiler
      */
     public static function stdFuncOpen(Tokenizer $tokens, Scope $scope)
     {
-        $scope["params"] = self::toArray($scope->tpl->parseParams($tokens));
+        $scope["params"] = var_export($scope->tpl->parseParams($tokens), true);
         return 'ob_start();';
     }
 
@@ -750,6 +750,7 @@ class Compiler
 
     /**
      * Convert array of code to string array
+	 * @deprecated
      * @param $params
      * @return string
      */

--- a/src/Fenom/Template.php
+++ b/src/Fenom/Template.php
@@ -1285,7 +1285,7 @@ class Template extends Render
         } else {
             $body = '?>' . $macro["body"] . '<?php';
         }
-        return '$_tpl' . $n . ' = $tpl->exchangeArray(' . Compiler::toArray($args) . ');' . PHP_EOL . $body . PHP_EOL . '$tpl->exchangeArray($_tpl' . $n . '); /* X */ unset($_tpl' . $n . ');';
+        return '$_tpl' . $n . ' = $tpl->exchangeArray(' . var_export($args, true) . ');' . PHP_EOL . $body . PHP_EOL . '$tpl->exchangeArray($_tpl' . $n . '); /* X */ unset($_tpl' . $n . ');';
     }
 
     /**


### PR DESCRIPTION
Замена Compiler::toArray на var_export($value, true). Функция объявлена deprecated
