### PR TITLE
Глобальная переменная в качестве параметра

### DIFF
--- a/src/Fenom/Template.php
+++ b/src/Fenom/Template.php
@@ -1455,6 +1455,7 @@ class Template extends Render
             if (!$arg && $tokens->is(
                     T_VARIABLE,
                     T_STRING,
+                    "$",
                     "(",
                     Tokenizer::MACRO_SCALAR,
                     '"',


### PR DESCRIPTION
Использование глобальных переменных в качестве параметров функций и методов:
object->method($.post.id)