### PR TITLE
Доступ к последовательности методов

### DIFF
--- a/src/Fenom/Accessor.php
+++ b/src/Fenom/Accessor.php
@@ -74,6 +74,17 @@ class Accessor {
     {
         return self::parserCall('$tpl->getStorage()->'.$method, $tokens, $tpl);
     }
+    
+    /**
+     * @param string $chain chain methods
+     * @param Tokenizer $tokens
+     * @param Template $tpl
+     * @return string
+     */
+    public static function parserChain($chain, Tokenizer $tokens, Template $tpl)
+    {
+        return $tpl->parseChain($tokens, '$tpl->getStorage()->'. $chain);
+    }
 
     /**
      * Accessor for global variables


### PR DESCRIPTION
Парсер Fenom::ACCESSOR_CHAIN позволит обратится к указанной последовательности свойств и методов шаблонизатора из шаблона.
