### PR TITLE
Доступ к последовательности методов

### DIFF
--- a/src/Fenom.php
+++ b/src/Fenom.php
@@ -59,6 +59,7 @@ class Fenom
     const ACCESSOR_CALL     = 'Fenom\Accessor::parserCall';
     const ACCESSOR_PROPERTY = 'Fenom\Accessor::parserProperty';
     const ACCESSOR_METHOD   = 'Fenom\Accessor::parserMethod';
+    const ACCESSOR_CHAIN    = 'Fenom\Accessor::parserChain';
 
     public static $charset = "UTF-8";
 


### PR DESCRIPTION
Парсер Fenom::ACCESSOR_CHAIN позволит обратится к указанной последовательности свойств и методов шаблонизатора из шаблона.