### PR TITLE
Add MODX_SOFT_MODE

### DIFF
--- a/src/Fenom.php
+++ b/src/Fenom.php
@@ -40,6 +40,7 @@ class Fenom
     const AUTO_TRIM         = 0x1000; // reserved
     const DENY_PHP_CALLS    = 0x2000;
     const AUTO_STRIP        = 0x4000;
+    const MODX_SOFT_MODE    = 0x8000; //This option for MODX, when compiling a Fenom tag error, enables the output of this tag as is. To inverse JS / JSON.
     /**
      * Use DENY_PHP_CALLS
      * @deprecated
@@ -87,6 +88,7 @@ class Fenom
         "disable_php_calls"    => self::DENY_PHP_CALLS,
         "disable_statics"      => self::DENY_STATICS,
         "strip"                => self::AUTO_STRIP,
+        "modx_soft_mode"       => self::MODX_SOFT_MODE,
     );
 
     /**


### PR DESCRIPTION
Add option MODX_SOFT_MODE. This option, when compiling a Fenom tag error, enables the output of this tag as is and output error in pdoTools for MODX log . To inverse JS / JSON code on MODX template.
Discussion in topics https://github.com/fenom-template/fenom/issues/308 and https://modx.pro/help/19203