### PR TITLE
Fix `Fenom::isAllowedFunction()`

### DIFF
--- a/src/Fenom.php
+++ b/src/Fenom.php
@@ -201,6 +201,11 @@ class Fenom
     );
 
     /**
+     * @var string[] the disabled functions by `disable_functions` PHP's option
+     */
+    protected $_disabled_funcs;
+
+    /**
      * @var array[] of compilers and functions
      */
     protected $_actions = array(
@@ -769,16 +774,24 @@ class Fenom
     }
 
     /**
-     * @param string $function
+     * Checks if is allowed PHP function for using in templates.
+     *
+     * @param string $function the function name
      * @return bool
      */
     public function isAllowedFunction($function)
     {
-        if ($this->_options & self::DENY_NATIVE_FUNCS) {
-            return isset($this->_allowed_funcs[$function]);
-        } else {
-            return is_callable($function);
+        $function = (string) $function;
+        if (!is_array($this->_disabled_funcs)) {
+            $disabled = ini_get('disable_functions');
+            $this->_disabled_funcs = empty($disabled) ? [] : explode(',', $disabled);
         }
+
+        if ($this->_options & self::DENY_NATIVE_FUNCS) {
+            return isset($this->_allowed_funcs[$function]) && !in_array($function, $this->_disabled_funcs, true);
+        }
+
+        return function_exists($function) && !in_array($function, $this->_disabled_funcs, true);
     }
 
     /**


### PR DESCRIPTION
- Checks if function in `ini_get('disable_functions')`
- Always disable execution functions like as `exec()`
- Replace `is_callable()` to `function_exists()` to ignore invokable classes