### PR TITLE
Fix {add $var}content{/add} generates invalid PHP

### DIFF
--- a/src/Fenom/Compiler.php
+++ b/src/Fenom/Compiler.php
@@ -693,9 +693,9 @@ class Compiler
         } else {
             $scope["name"] = $var;
             if ($tokens->is('|')) {
-                $scope["value"] = $before . $scope->tpl->parseModifier($tokens, "ob_get_clean()").';'.$after;
+                $scope["value"] = $scope->tpl->parseModifier($tokens, "ob_get_clean()").';';
             } else {
-                $scope["value"] = $before . "ob_get_clean();" . $after;
+                $scope["value"] = "ob_get_clean();";
             }
             return 'ob_start();';
         }
@@ -708,6 +708,9 @@ class Compiler
      */
     public static function setClose(Tokenizer $tokens, Tag $scope): string
     {
+        if ($scope->name === 'add') {
+            return "if(!isset(" . $scope["name"] . ")) {\n" . $scope["name"] . '=' . $scope["value"] . ";\n} else {\n    ob_end_clean();\n}";
+        }
         return $scope["name"] . '=' . $scope["value"] . ';';
     }
 

--- a/tests/cases/Fenom/TemplateTest.php
+++ b/tests/cases/Fenom/TemplateTest.php
@@ -441,6 +441,9 @@ class TemplateTest extends TestCase
             array('Create: {set $v = $x+$y} Result: {$v} end', $a, 'Create: Result: 36 end'),
             array('Create: {add $x = $x+$y} Result: {$x} end', $a, 'Create: Result: 9 end'),
             array('Create: {add $v = 3} {add $v = 9} Result: {$v} end', $a, 'Create: Result: 3 end'),
+            array('Create: {add $v}Hello{/add} Result: {$v} end', $a, 'Create: Result: Hello end'),
+            array('Create: {add $v}Value: {$x}{/add} Result: {$v} end', $a, 'Create: Result: Value: 9 end'),
+            array('Create: {set $v = "first"}{add $v}second{/add} Result: {$v} end', $a, 'Create: Result: first end'),
             array(
                 'Create: {set $v =
                             $x


### PR DESCRIPTION
## Fix for Issue #348

### Problem
When using `{add \$var}content{/add}` without explicit value assignment, the generated PHP code was invalid:

```php
$var = if(!isset($var)) {
    ob_get_clean();
}
```

This caused a parse error: "syntax error, unexpected token 'if'".

### Solution
Changed `setClose` in `Compiler.php` to wrap the ENTIRE assignment in the IF condition, not just the value part:

```php
if(!isset($var)) {
    $var = ob_get_clean();
} else {
    ob_end_clean();
}
```

This correctly:
- Captures content into variable if variable is NOT set
- Discards buffer without outputting if variable IS already set

### Tests Added
- `{add $v}Hello{/add} Result: {$v}` - basic capture
- `{add $v}Value: {$x}{/add}` - capture with variable interpolation  
- `{set $v = "first"}{add $v}second{/add}` - verify {add} does NOT overwrite existing variable

### Fixes
Fixes #348