### PR TITLE
Fix documentation: remove deprecated registerAutoload()

### DIFF
--- a/docs/en/start.md
+++ b/docs/en/start.md
@@ -1,5 +1,5 @@
 Basic usage
-===========
+==========
 
 ## Install Fenom
 
@@ -9,22 +9,21 @@ Add package Fenom in your require-list in `composer.json`:
 ```json
 {
     "require": {
-        "fenom/fenom": "2.*"
+        "fenom/fenom": "^3.0"
     }
 }
 ```
 and update project's dependencies: `composer update`.
 
-### Custom loader
+### Manual Installation
 
-Clone Fenom to any directory: `git clone https://github.com/bzick/fenom.git`. Recommended use latest tag.
-Fenom use [psr-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md#autoloading-standard) autoloading standard. Therefore you can
-* use `psr-0` format in your project loader for loading Fenom's classes
-* or register Fenom's autoloader: `Fenom::registerAutoload();` for loading itself.
+Clone Fenom to any directory: `git clone https://github.com/fenom-template/fenom.git`.
 
-Also you can use this autoloader for loading any library with `psr-0` file naming:
+Fenom uses [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) autoloading standard.
+Include Composer's autoloader or use any PSR-4 compatible autoloader:
+
 ```php
-Fenom::registerAutoload(PROJECT_DIR."/src");
+require_once '/path/to/vendor/autoload.php';
 ```
 
 ## Setup Fenom
@@ -36,7 +35,7 @@ $fenom = Fenom::factory('/path/to/templates', '/path/to/compiled/template', $opt
 
 Create an object via `new` operator
 ```php
-$fenom = new Fenom(new Provider('/path/to/templates'));
+$fenom = new Fenom(new Fenom\Provider('/path/to/templates'));
 $fenom->setCompileDir('/path/to/template/cache');
 $fenom->setOptions($options);
 ```

--- a/docs/ru/start.md
+++ b/docs/ru/start.md
@@ -1,5 +1,5 @@
 Быстрый старт
-=============
+============
 
 ## Установка Fenom
 
@@ -10,23 +10,21 @@ Fenom зарегистрирован на [packagist.org](https://packagist.org/
 ```json
 {
     "require": {
-        "fenom/fenom": "2.*"
+        "fenom/fenom": "^3.0"
     }
 }
 ```
 и обновите зависимости: `composer update`.
 
-### Произвольная подгрузка
+### Ручная установка
 
-Клонируйте Fenom в любую директорию Вашего проекта: `git clone https://github.com/bzick/fenom.git`. Рекомендуется использовать последнюю версию.
-Для загрузки классов Fenom использует [psr-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md#autoloading-standard) стандарт.
-Таким образом вы можете:
-* использовать Ваш автозагрузчик, который понимает `psr-0` формат для загрузки классов Fenom из директории `src/` с пространством имен `Fenom`.
-* или использовать встроенный автозагрузчик Fenom: `Fenom::registerAutoload();` для загрузки самого себя.
+Клонируйте Fenom в любую директорию Вашего проекта: `git clone https://github.com/fenom-template/fenom.git`.
 
-Так же вы можете использовать встроенный в Fenom автозагрузчик для загрузки других классов в `psr-0` формате:
+Fenom использует [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) стандарт автозагрузки.
+Подключите autoloader Composer или любой другой PSR-4 совместимый загрузчик:
+
 ```php
-Fenom::registerAutoload(PROJECT_DIR."/classes");
+require_once '/path/to/vendor/autoload.php';
 ```
 
 ## Настройка Fenom
@@ -81,30 +79,3 @@ $fenom->pipe(
 
 Поток позволяет обрабатывать большой результат по кускам, размер куска указывается в байтах аргументом `$chunk_size`.
 Каждый кусок передается в `$callback` для обработки или вывода.
-
-<!--
-## Пример простого приложения
-
-```
-App/ (ROOT_DIR)
- ┠─ configs/ (файлы конфигурации приложения)
- ┠─ src/ (классы приложения)
- ┠─ templates/ (шаблоны приложения)
- ┠─ public/ (DOCUMENT_ROOT)
- ┃   ┠─ static/ (папка со статикой) 
- ┃   ┖─ index.php (скрипт обработки всех динамических запросов)
- ┠─ tmp/ (папка доступная для записи web-серверу для хранения временных файлов)
- ┃   ┖─ compiled/ (кеша шаблонов)
- ┠─ vendor/ (строронние бибилиотеки)
- ┖─ composer.json (описание зависимостей для composer) 
-```
-
-`index.php`:
-```php
-define('ROOT_DIR', dirname(__DIR__));
-
-$fenom = Fenom::factory(ROOT_DIR.'/templates', ROOT_DIR.'/cache', Fenom::FORCE_VERIFY | Fenom::AUTO_RELOAD);
-
-
-```
--->


### PR DESCRIPTION
## Fix for Issue #346

### Problem
Documentation mentioned `Fenom::registerAutoload()` method which doesn't exist in Fenom 3.x. This confused users migrating from Fenom 2.x.

### Changes
- Updated composer requirement from `2.*` to `^3.0`
- Removed section about deprecated `registerAutoload()` method
- Updated installation instructions to use Composer's autoloader
- Updated old GitHub URL from `bzick/fenom` to `fenom-template/fenom`

### Files Changed
- `docs/en/start.md`
- `docs/ru/start.md`

### Before (outdated)
```php
include '/path/to/fenom/src/Fenom.php';
Fenom::registerAutoload();
```

### After (correct)
```php
require_once '/path/to/vendor/autoload.php';
// That's it - Composer autoloader handles everything
```

Fixes #346